### PR TITLE
feat(Timeout): Re-add timeout as part of the lock/wait contract

### DIFF
--- a/KeyedSemaphores/KeyedSemaphore.cs
+++ b/KeyedSemaphores/KeyedSemaphore.cs
@@ -15,15 +15,19 @@ namespace KeyedSemaphores
         ///     Asynchronously gets or creates a keyed semaphore with the provided key and immediately acquires a lock on it.
         /// </summary>
         /// <param name="key">The unique key of this keyed semaphore</param>
+        /// <param name="timeout">
+        /// Time to wait for lock. By default wait indefinitely.
+        /// </param>
         /// <param name="cancellationToken">A cancellation token that will interrupt trying to acquire the lock</param>
         /// <returns>
         ///     An instance of <see cref="KeyedSemaphore{TKey}" /> that has already acquired a lock on the inner <see cref="SemaphoreSlim" />
         /// </returns>
-        public static Task<IDisposable> LockAsync(string key, CancellationToken cancellationToken = default)
+        public static Task<IDisposable> LockAsync(string key, TimeSpan timeout = default, CancellationToken cancellationToken = default)
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
-            return Collection.LockAsync(key, cancellationToken);
+            return Collection.LockAsync(key, timeout, cancellationToken);
         }
+
 
         /// <summary>
         ///     Synchronously gets or creates a keyed semaphore with the provided key and immediately acquires a lock on it.
@@ -32,15 +36,18 @@ namespace KeyedSemaphores
         ///     This method will block the current thread until the keyed semaphore lock is acquired.
         ///     If possible, consider using the asynchronous <see cref="LockAsync" /> method which does not block the thread
         /// </remarks>
+        /// <param name="timeout">
+        /// Time to wait for lock. By default wait indefinitely.
+        /// </param>
         /// <param name="key">The unique key of this keyed semaphore</param>
         /// <param name="cancellationToken">A cancellation token that will interrupt trying to acquire the lock</param>
         /// <returns>
         ///     An instance of <see cref="KeyedSemaphore{TKey}" /> that has already acquired a lock on the inner <see cref="SemaphoreSlim" />
         /// </returns>
-        public static IDisposable Lock(string key, CancellationToken cancellationToken = default)
+        public static IDisposable Lock(string key, TimeSpan timeout = default, CancellationToken cancellationToken = default)
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
-            return Collection.Lock(key, cancellationToken);
+            return Collection.Lock(key, timeout, cancellationToken);
         }
     }
 }

--- a/KeyedSemaphores/KeyedSemaphoresCollection.cs
+++ b/KeyedSemaphores/KeyedSemaphoresCollection.cs
@@ -55,7 +55,7 @@ namespace KeyedSemaphores
                     keyedSemaphore.Consumers++;
 
                     Monitor.Exit(keyedSemaphore);
-                    
+
                     return keyedSemaphore;
                 }
 
@@ -67,22 +67,26 @@ namespace KeyedSemaphores
                 }
             }
         }
-        
+
         /// <summary>
         ///     Gets or creates a keyed semaphore with the provided key and immediately acquires a lock on it
         /// </summary>
         /// <param name="key">The unique key of this keyed semaphore</param>
+        /// <param name="timeout">
+        /// Time to wait for lock. By default wait indefinitely.
+        /// </param>
         /// <param name="cancellationToken">A cancellation token that will interrupt trying to acquire the lock</param>
         /// <returns>
         ///     An instance of <see cref="KeyedSemaphore{TKey}" /> that has already acquired a lock on the inner <see cref="SemaphoreSlim" />
         /// </returns>
-        public async Task<IDisposable> LockAsync(TKey key, CancellationToken cancellationToken = default)
+        public async Task<IDisposable> LockAsync(TKey key, TimeSpan timeout = default, CancellationToken cancellationToken = default)
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
+            if (timeout == default) timeout = Timeout.InfiniteTimeSpan;
 
             var keyedSemaphore = Provide(key);
 
-            await keyedSemaphore.SemaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await keyedSemaphore.SemaphoreSlim.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
 
             return keyedSemaphore.Releaser;
         }
@@ -95,17 +99,21 @@ namespace KeyedSemaphores
         ///     If possible, consider using the asynchronous <see cref="LockAsync" /> method which does not block the thread
         /// </remarks>
         /// <param name="key">The unique key of this keyed semaphore</param>
+        /// <param name="timeout">
+        /// Time to wait for lock. By default wait indefinitely.
+        /// </param>
         /// <param name="cancellationToken">A cancellation token that will interrupt trying to acquire the lock</param>
         /// <returns>
         ///     An instance of <see cref="KeyedSemaphore{TKey}" /> that has already acquired a lock on the inner <see cref="SemaphoreSlim" />
         /// </returns>
-        public IDisposable Lock(TKey key, CancellationToken cancellationToken = default)
+        public IDisposable Lock(TKey key, TimeSpan timeout = default, CancellationToken cancellationToken = default)
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
+            if (timeout == default) timeout = Timeout.InfiniteTimeSpan;
 
             var keyedSemaphore = Provide(key);
 
-            keyedSemaphore.SemaphoreSlim.Wait(cancellationToken);
+            keyedSemaphore.SemaphoreSlim.Wait(timeout, cancellationToken);
 
             return keyedSemaphore.Releaser;
         }


### PR DESCRIPTION
Fixes #23 

# Checklist
- [x] The pull request branch is in sync with latest commit on the *amoerie/keyed-semaphores* development branch
- [x] I have included unit tests
- [ ] I have updated CHANGELOG.MD
- [ ] I am listed in the CONTRIBUTORS.MD file

# Description of changes in this pull request
Re add the removed timeout setting on locks to let the dev choose if they want to wait indefinitely or not.

# Public API Changes
Add optional parameter timeout to all lock functions. Default to current behavior where we don't timeout.
