### PR TITLE
feat(Exception): Delay throwing exception after release of lock

### DIFF
--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -4,3 +4,4 @@
 
 * [Alexander Moerman](https://github.com/amoerie)
 * [Roel de Regt](https://github.com/roel-de-regt)
+* [Antoine Aflalo](https://github.com/Belphemur)

--- a/KeyedSemaphores.Tests/TestForCancellationTokenAndTimeout.cs
+++ b/KeyedSemaphores.Tests/TestForCancellationTokenAndTimeout.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace KeyedSemaphores.Tests;
+
+public class TestForCancellationTokenAndTimeout
+{
+    [Fact]
+    public async Task TestLockReleasedOnCancellation()
+    {
+        var collection = new KeyedSemaphoresCollection<string>();
+
+        using var cts = new CancellationTokenSource(0);
+
+        var action = async () =>
+        {
+            using var locking = await collection.LockAsync("test", default, cts.Token);
+        };
+
+        await action.Should().ThrowAsync<OperationCanceledException>();
+
+        collection.Index.Should().NotContainKey("test");
+    }
+}

--- a/KeyedSemaphores/KeyedSemaphoreReleaser.cs
+++ b/KeyedSemaphores/KeyedSemaphoreReleaser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 
 namespace KeyedSemaphores
@@ -10,6 +11,10 @@ namespace KeyedSemaphores
     {
         private readonly KeyedSemaphoresCollection<TKey> _collection;
         private readonly KeyedSemaphore<TKey> _keyedSemaphore;
+        /// <summary>
+        /// To be sure to pass any exception from the time we got the lock to it's release
+        /// </summary>
+        internal Exception? Exception { get; set; }
 
         internal KeyedSemaphoreReleaser(
             KeyedSemaphoresCollection<TKey> collection,
@@ -46,6 +51,10 @@ namespace KeyedSemaphores
             }
 
             _keyedSemaphore.SemaphoreSlim.Release();
+            if (Exception != null)
+            {
+                ExceptionDispatchInfo.Capture(Exception).Throw();
+            }
         }
     }
 }

--- a/KeyedSemaphores/KeyedSemaphoresCollection.cs
+++ b/KeyedSemaphores/KeyedSemaphoresCollection.cs
@@ -85,8 +85,14 @@ namespace KeyedSemaphores
             if (timeout == default) timeout = Timeout.InfiniteTimeSpan;
 
             var keyedSemaphore = Provide(key);
-
-            await keyedSemaphore.SemaphoreSlim.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await keyedSemaphore.SemaphoreSlim.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                keyedSemaphore.Releaser.Exception = e;
+            }
 
             return keyedSemaphore.Releaser;
         }
@@ -112,8 +118,14 @@ namespace KeyedSemaphores
             if (timeout == default) timeout = Timeout.InfiniteTimeSpan;
 
             var keyedSemaphore = Provide(key);
-
-            keyedSemaphore.SemaphoreSlim.Wait(timeout, cancellationToken);
+            try
+            {
+                keyedSemaphore.SemaphoreSlim.Wait(timeout, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                keyedSemaphore.Releaser.Exception = e;
+            }
 
             return keyedSemaphore.Releaser;
         }


### PR DESCRIPTION
See #24 

# Checklist
- [x] The pull request branch is in sync with latest commit on the *amoerie/keyed-semaphores* development branch
- [x] I have included unit tests
- [] I have updated CHANGELOG.MD
- [x] I am listed in the CONTRIBUTORS.MD file

# Description of changes in this pull request
Manage properly any exceptions thrown by the waiting of the lock and be sure to propagate them after we release the lock to be sure the lock is always released after usage.
