### PR TITLE
Add support for Contains(key) for KeyedSemaphoresCollection

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 # 🔑🔒 Changelog
 
+# 3.2 January 18th, 2023
+
+- Add support to check if key already locked with Contains(key) API
+
 # 3.1 October 28th, 2022
 
 - Add support for timeout with TryLock(Async) API

--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -5,3 +5,4 @@
 * [Alexander Moerman](https://github.com/amoerie)
 * [Roel de Regt](https://github.com/roel-de-regt)
 * [Antoine Aflalo](https://github.com/Belphemur)
+* [Serhii Slepokurov](https://github.com/knopa)

--- a/KeyedSemaphores/KeyedSemaphoresCollection.cs
+++ b/KeyedSemaphores/KeyedSemaphoresCollection.cs
@@ -335,5 +335,22 @@ namespace KeyedSemaphores
 
             return true;
         }
+
+        /// <summary>
+        ///     Check if keyed semaphore already has the provided unique key
+        /// </summary>
+        /// <param name="key">
+        ///     The unique key of this keyed semaphore
+        /// </param>
+        /// <returns>
+        ///     True when key are already locked
+        ///     False when key are available for lock
+        /// </returns>
+        public bool ContainsKey(TKey key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            return Index.ContainsKey(key);
+        }
     }
 }


### PR DESCRIPTION
# Checklist
- [yes] The pull request branch is in sync with latest commit on the *amoerie/keyed-semaphores* development branch
- [yes] I have included unit tests
- [yes] I have updated CHANGELOG.MD
- [yes] I am listed in the CONTRIBUTORS.MD file

# Description of changes in this pull request
Add Contains(key) method to KeyedSemaphoresCollection

# Public API Changes
add new method
