### PR TITLE
Restore .NET Standard 2.0 target

### DIFF
--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -6,3 +6,4 @@
 * [Roel de Regt](https://github.com/roel-de-regt)
 * [Antoine Aflalo](https://github.com/Belphemur)
 * [Serhii Slepokurov](https://github.com/knopa)
+* [Guerra24](https://github.com/Guerra24)

--- a/KeyedSemaphores/KeyedSemaphores.csproj
+++ b/KeyedSemaphores/KeyedSemaphores.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
     <Title>Keyed Semaphores</Title>
@@ -22,7 +22,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 


### PR DESCRIPTION
# Checklist
- [x] The pull request branch is in sync with latest commit on the *amoerie/keyed-semaphores* development branch
- [ ] I have included unit tests
- [ ] I have updated CHANGELOG.MD
- [x] I am listed in the CONTRIBUTORS.MD file

# Description of changes in this pull request
Restores .NET Standard 2.0 target. Its removal causes warnings in UWP and .NET Standard 2.1 projects.

# Public API Changes
None
