### PR TITLE
Introduced `TryLockAsync` equivalent returning `Task<IDisposable>`

### DIFF
--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -7,3 +7,4 @@
 * [Antoine Aflalo](https://github.com/Belphemur)
 * [Serhii Slepokurov](https://github.com/knopa)
 * [Guerra24](https://github.com/Guerra24)
+* [Rhys](https://github.com/xanth)

--- a/KeyedSemaphores.Tests/TestsForKeyedSemaphoresCollection.cs
+++ b/KeyedSemaphores.Tests/TestsForKeyedSemaphoresCollection.cs
@@ -735,7 +735,7 @@ public class TestsForKeyedSemaphoresCollection
         // Arrange
         var dictionary = new KeyedSemaphoresDictionary<string>();
         var key = "test";
-        var jobComplet = false;
+        var jobComplete = false;
         var jobEntered = false;
         var timeout = useShortTimeout
             ? Constants.DefaultSynchronousWaitDuration.Subtract(TimeSpan.FromMilliseconds(1))
@@ -747,7 +747,7 @@ public class TestsForKeyedSemaphoresCollection
 
             using var _ = await dictionary.TryLockAsync(key, TimeSpan.FromDays(1));
             
-            jobComplet = true;
+            jobComplete = true;
 
             return true;
         }
@@ -759,13 +759,13 @@ public class TestsForKeyedSemaphoresCollection
         // Assert
         lockScopeOne.Should().NotBeNull();
         jobEntered.Should().BeTrue();
-        jobComplet.Should().BeFalse();
+        jobComplete.Should().BeFalse();
         dictionary.IsInUse(key).Should().BeTrue();
         
         lockScopeOne!.Dispose(); // Release the lock to allow the callback to proceed
 
         (await callbackTask).Should().BeTrue();
         dictionary.IsInUse(key).Should().BeFalse();
-        jobComplet.Should().BeTrue();
+        jobComplete.Should().BeTrue();
     }
 }

--- a/KeyedSemaphores.Tests/TestsForKeyedSemaphoresDictionary.cs
+++ b/KeyedSemaphores.Tests/TestsForKeyedSemaphoresDictionary.cs
@@ -681,4 +681,91 @@ public class TestsForKeyedSemaphoresDictionary
         isCallbackInvoked.Should().BeTrue();
         dictionary.IsInUse(key).Should().BeFalse();
     }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TryLockAsync_WithoutCallback_ShouldReturnDisposable(bool useShortTimeout)
+    {
+        // Arrange
+        var dictionary = new KeyedSemaphoresDictionary<string>();
+        var key = "test";
+        var timeout = useShortTimeout
+            ? Constants.DefaultSynchronousWaitDuration.Subtract(TimeSpan.FromMilliseconds(1))
+            : Constants.DefaultSynchronousWaitDuration.Add(TimeSpan.FromMilliseconds(1));
+
+        // Act
+        using (var lockScope = await dictionary.TryLockAsync(key, timeout))
+        {
+            // Assert
+            lockScope.Should().NotBeNull();
+            dictionary.IsInUse(key).Should().BeTrue("Lock should be held inside the using block");
+        }
+
+        dictionary.IsInUse(key).Should().BeFalse("Lock should be released outside the using block");
+    }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TryLockAsync_WithoutCallback_ShouldBlockConflictingTryLockAsync(bool useShortTimeout)
+    {
+        // Arrange
+        var dictionary = new KeyedSemaphoresDictionary<string>();
+        var key = "test";
+        var timeout = useShortTimeout
+            ? Constants.DefaultSynchronousWaitDuration.Subtract(TimeSpan.FromMilliseconds(1))
+            : Constants.DefaultSynchronousWaitDuration.Add(TimeSpan.FromMilliseconds(1));
+
+        // Act
+        using var lockScopeOne = await dictionary.TryLockAsync(key, timeout);
+        using var lockScopeTwo = await dictionary.TryLockAsync(key, timeout);
+        
+        // Assert
+        lockScopeOne.Should().NotBeNull();
+        lockScopeTwo.Should().BeNull("Second TryLockAsync should fail due to the lock being held by the first");
+        dictionary.IsInUse(key).Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TryLockAsync_WithoutCallback_ShouldBlockConflictingTryLockAsync_UntilDisposed(bool useShortTimeout)
+    {
+        // Arrange
+        var dictionary = new KeyedSemaphoresDictionary<string>();
+        var key = "test";
+        var jobComplet = false;
+        var jobEntered = false;
+        var timeout = useShortTimeout
+            ? Constants.DefaultSynchronousWaitDuration.Subtract(TimeSpan.FromMilliseconds(1))
+            : Constants.DefaultSynchronousWaitDuration.Add(TimeSpan.FromMilliseconds(1));
+
+        async Task<bool> Job()
+        {
+            jobEntered = true;
+
+            using var _ = await dictionary.TryLockAsync(key, TimeSpan.FromDays(1));
+            
+            jobComplet = true;
+
+            return true;
+        }
+
+        // Act
+        var lockScopeOne = await dictionary.TryLockAsync(key, timeout);
+        var callbackTask = Job();
+        
+        // Assert
+        lockScopeOne.Should().NotBeNull();
+        jobEntered.Should().BeTrue();
+        jobComplet.Should().BeFalse();
+        dictionary.IsInUse(key).Should().BeTrue();
+        
+        lockScopeOne!.Dispose(); // Release the lock to allow the callback to proceed
+
+        (await callbackTask).Should().BeTrue();
+        dictionary.IsInUse(key).Should().BeFalse();
+        jobComplet.Should().BeTrue();
+    }
 }

--- a/KeyedSemaphores/IKeyedSemaphoresCollection.cs
+++ b/KeyedSemaphores/IKeyedSemaphoresCollection.cs
@@ -83,6 +83,30 @@ namespace KeyedSemaphores
         ///     <paramref name="cancellationToken">cancellationToken</paramref> was canceled.
         /// </exception>
         ValueTask<bool> TryLockAsync(TKey key, TimeSpan timeout, Func<Task> callback, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        ///     Gets or creates a keyed semaphore with the provided unique key
+        ///     and immediately tries to lock on the inner <see cref="SemaphoreSlim"/> using the provided <paramref name="timeout"/> and <paramref name="cancellationToken"/>
+        /// </summary>
+        /// <param name="key">
+        ///     The unique key of this keyed semaphore
+        /// </param>
+        /// <param name="timeout">
+        ///     A <see cref="T:System.TimeSpan" /> that represents the number of milliseconds to wait
+        ///     , a <see cref="T:System.TimeSpan" /> that represents -1 milliseconds to wait indefinitely
+        ///     , or a <see cref="T:System.TimeSpan" /> that represents 0 milliseconds to test the wait handle and return immediately.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     The <see cref="T:System.Threading.CancellationToken"></see> token to observe.
+        /// </param>
+        /// <returns>
+        ///     True when locking the inner <see cref="SemaphoreSlim"/> succeeded and the callback was invoked. 
+        ///     False when locking the inner <see cref="SemaphoreSlim"/> failed and the callback was not invoked. 
+        /// </returns>
+        /// <exception cref="T:System.OperationCanceledException">
+        ///     <paramref name="cancellationToken">cancellationToken</paramref> was canceled.
+        /// </exception>
+        ValueTask<IDisposable?> TryLockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Gets or creates a keyed semaphore with the provided unique key

--- a/KeyedSemaphores/IKeyedSemaphoresCollection.cs
+++ b/KeyedSemaphores/IKeyedSemaphoresCollection.cs
@@ -100,8 +100,8 @@ namespace KeyedSemaphores
         ///     The <see cref="T:System.Threading.CancellationToken"></see> token to observe.
         /// </param>
         /// <returns>
-        ///     True when locking the inner <see cref="SemaphoreSlim"/> succeeded and the callback was invoked. 
-        ///     False when locking the inner <see cref="SemaphoreSlim"/> failed and the callback was not invoked. 
+        ///     Non <see langword="null"/> <see cref="IDisposable"/> when locking the inner <see cref="SemaphoreSlim"/> succeeded. 
+        ///     <see langword="null"/> when locking the inner <see cref="SemaphoreSlim"/> failed. 
         /// </returns>
         /// <exception cref="T:System.OperationCanceledException">
         ///     <paramref name="cancellationToken">cancellationToken</paramref> was canceled.

--- a/KeyedSemaphores/KeyedSemaphore.cs
+++ b/KeyedSemaphores/KeyedSemaphore.cs
@@ -46,6 +46,13 @@ namespace KeyedSemaphores
             return Dictionary.TryLock(key, timeout, callback, cancellationToken);
         }
 
+        /// <inheritdoc cref="IKeyedSemaphoresCollection{TKey}.TryLockAsync(TKey,System.TimeSpan,System.Threading.CancellationToken)" />
+        public static async ValueTask<IDisposable?> TryLockAsync(string key, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            return await Dictionary.TryLockAsync(key, timeout, cancellationToken);
+        }
+
         /// <inheritdoc cref="IKeyedSemaphoresCollection{TKey}.IsInUse" />
         public static bool IsInUse(string key)
         {

--- a/README.MD
+++ b/README.MD
@@ -317,7 +317,7 @@ using(await KeyedSemaphore.LockAsync("123", cancellationToken))
 using var lockScope = await KeyedSemaphore.TryLockAsync("123", TimeSpan.FromSeconds(42), cancellationToken);
 if (lockScope is not null) 
 {
-  // Your code here
+  // Your critical section here
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -361,8 +361,10 @@ Usage:
 using var lockScope = await KeyedSemaphore.TryLockAsync("123", TimeSpan.FromSeconds(42), cancellationToken);
 if (lockScope is not null) 
 {
-  // Your critical section here
+  // Return from your critical section here
 }
+
+// Return from your non critical section here
 ```
 
 # Alternatives

--- a/README.MD
+++ b/README.MD
@@ -300,7 +300,7 @@ The following methods support cancellation and will throw an `OperationCanceledE
 interface IKeyedSemaphoresCollection<TKey> 
 {
   IDisposable Lock(TKey key, CancellationToken cancellationToken = default)
-  Task<IDisposable> LockAsync(TKey key, CancellationToken cancellationToken = default);
+  Task<IDisposable> LockAsync(TKey key, CancellationToken cancellationToken = default)
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -301,7 +301,6 @@ interface IKeyedSemaphoresCollection<TKey>
 {
   IDisposable Lock(TKey key, CancellationToken cancellationToken = default)
   Task<IDisposable> LockAsync(TKey key, CancellationToken cancellationToken = default);
-  Task<IDisposable?> TryLockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default)
 }
 ```
 
@@ -312,12 +311,6 @@ CancellationToken cancellationToken = ...;
 using(await KeyedSemaphore.LockAsync("123", cancellationToken)) 
 {
   // Your code here
-}
-
-using var lockScope = await KeyedSemaphore.TryLockAsync("123", TimeSpan.FromSeconds(42), cancellationToken);
-if (lockScope is not null) 
-{
-  // Your critical section here
 }
 ```
 
@@ -332,13 +325,12 @@ interface IKeyedSemaphoresCollection<TKey>
   bool TryLock(TKey key, TimeSpan timeout, Action callback, CancellationToken cancellationToken = default)
   Task<bool> TryLockAsync(TKey key, TimeSpan timeout, Action callback, CancellationToken cancellationToken = default)
   Task<bool> TryLockAsync(TKey key, TimeSpan timeout, Func<Task> callback, CancellationToken cancellationToken = default)
-  ValueTask<IDisposable?> TryLockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default);
 }
 ```
 
 Usage:
 
-```csharp
+```csharp 
 CancellationToken cancellationToken = ...;
 if(await KeyedSemaphore.TryLockAsync("123", TimeSpan.FromSeconds(10), CallbackAsync, cancellationToken)) 
 {
@@ -348,6 +340,28 @@ if(await KeyedSemaphore.TryLockAsync("123", TimeSpan.FromSeconds(10), CallbackAs
 async Task CallbackAsync() 
 {
   // Your code here
+}
+```
+
+## Advanced Timeout & Cancellation
+
+The following methods support timeout _and_ cancellation but **without** _callback_ parameter.
+Note that these methods return a nullable `IDisposable` that as such **must** be disposed, its highly recommended to follow the nullcheck pattern shown below for correct, performant behavior.
+
+```csharp
+interface IKeyedSemaphoresCollection<TKey> 
+{
+  ValueTask<IDisposable?> TryLockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default)
+}
+```
+
+Usage:
+
+```csharp
+using var lockScope = await KeyedSemaphore.TryLockAsync("123", TimeSpan.FromSeconds(42), cancellationToken);
+if (lockScope is not null) 
+{
+  // Your critical section here
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -332,6 +332,7 @@ interface IKeyedSemaphoresCollection<TKey>
   bool TryLock(TKey key, TimeSpan timeout, Action callback, CancellationToken cancellationToken = default)
   Task<bool> TryLockAsync(TKey key, TimeSpan timeout, Action callback, CancellationToken cancellationToken = default)
   Task<bool> TryLockAsync(TKey key, TimeSpan timeout, Func<Task> callback, CancellationToken cancellationToken = default)
+  ValueTask<IDisposable?> TryLockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default);
 }
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -301,6 +301,7 @@ interface IKeyedSemaphoresCollection<TKey>
 {
   IDisposable Lock(TKey key, CancellationToken cancellationToken = default)
   Task<IDisposable> LockAsync(TKey key, CancellationToken cancellationToken = default);
+  Task<IDisposable?> TryLockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default)
 }
 ```
 
@@ -309,6 +310,12 @@ Usage:
 ```csharp
 CancellationToken cancellationToken = ...;
 using(await KeyedSemaphore.LockAsync("123", cancellationToken)) 
+{
+  // Your code here
+}
+
+using var lockScope = await KeyedSemaphore.TryLockAsync("123", TimeSpan.FromSeconds(42), cancellationToken);
+if (lockScope is not null) 
 {
   // Your code here
 }


### PR DESCRIPTION
# Checklist
- [x] The pull request branch is in sync with latest commit on the *amoerie/keyed-semaphores* development branch
- [x] I have included unit tests
- [x] I have updated CHANGELOG.MD
- [x] I am listed in the CONTRIBUTORS.MD file

# Description of changes in this pull request
Introduced `TryLockAsync` equivalent returning `Task<IDisposable>` to protect thread sensitive blocks

I've had need for the method below and thought I'd contribute it back. Thanks for the great lib

# Public API Changes
Added `TryLockAsync` to `IKeyedSemaphoresCollection` and all concrete implementations 
```csharp
public interface IKeyedSemaphoresCollection<in TKey> where TKey : notnull
{
    ValueTask<IDisposable?> TryLockAsync(TKey key, TimeSpan timeout, CancellationToken cancellationToken = default);
}
```

Added `TryLockAsync` to `KeyedSemaphore` global static singleton
```csharp
public static class KeyedSemaphore
{
    public static async ValueTask<IDisposable?> TryLockAsync(string key, TimeSpan timeout, CancellationToken cancellationToken = default)
    {
        if (key == null) throw new ArgumentNullException(nameof(key));
        return await Dictionary.TryLockAsync(key, timeout, cancellationToken);
    }
}
```