### PR TITLE
Add .NET 10 support and update NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
+
       - name: Restore
         run: dotnet restore
         

--- a/KeyedSemaphores.Benchmarks/KeyedSemaphores.Benchmarks.csproj
+++ b/KeyedSemaphores.Benchmarks/KeyedSemaphores.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/KeyedSemaphores.Samples/KeyedSemaphores.Samples.csproj
+++ b/KeyedSemaphores.Samples/KeyedSemaphores.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/KeyedSemaphores.Tests/KeyedSemaphores.Tests.csproj
+++ b/KeyedSemaphores.Tests/KeyedSemaphores.Tests.csproj
@@ -2,19 +2,19 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net9.0;net481</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0;net481</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/KeyedSemaphores/KeyedSemaphores.csproj
+++ b/KeyedSemaphores/KeyedSemaphores.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net481</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net481</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
     <Title>Keyed Semaphores</Title>


### PR DESCRIPTION
## Summary
- Add `net10.0` as a target framework to all projects (library, tests, benchmarks, samples)
- Bump `Microsoft.NET.Test.Sdk` from 18.0.1 → 18.4.0
- Bump `coverlet.collector` from 8.0.0 → 8.0.1
- Add `actions/setup-dotnet@v4` step in CI with explicit SDK versions (8.x, 9.x, 10.x)

## Test plan
- [x] `dotnet build` succeeds with all target frameworks including `net10.0`
- [x] All 82 tests pass on `net9.0`, `net10.0`, and `net481`

🤖 Generated with [Claude Code](https://claude.com/claude-code)