### PR TITLE
Add GitHub Actions to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Configuration for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds a `github-actions` ecosystem entry to `dependabot.yml` so Dependabot will open PRs when new versions of actions used in `.github/workflows/` are released (e.g. `actions/checkout`, `codecov/codecov-action`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)